### PR TITLE
Enhancement/#2 standalone registration

### DIFF
--- a/app/menu.js
+++ b/app/menu.js
@@ -185,12 +185,10 @@ exports.createTemplate = (options, messages) => {
     const fileMenu = template[0];
 
     // These are in reverse order, since we're prepending them one at a time
-    if (options.development) {
-      fileMenu.submenu.unshift({
-        label: messages.menuSetupAsStandalone.message,
-        click: setupAsStandalone,
-      });
-    }
+    fileMenu.submenu.unshift({
+      label: messages.menuSetupAsStandalone.message,
+      click: setupAsStandalone,
+    });
 
     fileMenu.submenu.unshift({
       type: 'separator',

--- a/test/app/fixtures/menu-mac-os-setup.json
+++ b/test/app/fixtures/menu-mac-os-setup.json
@@ -49,6 +49,10 @@
         "type": "separator"
       },
       {
+        "label": "Set Up as Standalone Device",
+        "click": null
+      },
+      {
         "label": "Create/upload sticker pack",
         "click": null
       }

--- a/test/app/fixtures/menu-windows-linux-setup.json
+++ b/test/app/fixtures/menu-windows-linux-setup.json
@@ -10,6 +10,10 @@
         "type": "separator"
       },
       {
+        "label": "Set Up as Standalone Device",
+        "click": null
+      },
+      {
         "label": "Create/upload sticker pack",
         "click": null
       },


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description
This PR introduces the possibility to register a Signal-Desktop instance as the primary device.
For this the entry for opening the standalone registration view is now added to the menu in the production version as well.
The tests for the menu are changed accordingly.

resolves #2 