### PR TITLE
Enhancement/#6 change settings

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -1246,6 +1246,26 @@
     "message": "Spell check will be disabled the next time Signal starts.",
     "description": "Shown when the user disables spellcheck to indicate that they must restart Signal."
   },
+  "privacySettings": {
+    "message": "Privacy Settings",
+    "description": "Header for privacy options on the settings screen"
+  },
+  "sendReadReceipts": {
+    "message": "Send Read Receipts",
+    "description": "Label for setting to send read receipts"
+  },
+  "udIndicators": {
+    "message": "Send Unidentified Delivery Indicators",
+    "description": "Label for setting to send unidentified delivery indicators"
+  },
+  "typingIndicators": {
+    "message": "Typing Indicators",
+    "description": "Label for setting to send typing indicators"
+  },
+  "linkPreviews": {
+    "message": "Link Previews",
+    "description": "Label for setting to send link previews"
+  },
   "clearDataHeader": {
     "message": "Clear Data",
     "description": "Header in the settings dialog for the section dealing with data deletion"

--- a/js/settings_start.js
+++ b/js/settings_start.js
@@ -42,6 +42,11 @@ const getInitialData = async () => ({
   mediaPermissions: await window.getMediaPermissions(),
   mediaCameraPermissions: await window.getMediaCameraPermissions(),
 
+  readReceiptSetting: await window.getReadReceiptSetting(),
+  unidentifiedDeliveryIndicatorSetting: await window.getUnidentifiedDeliveryIndicatorSetting(),
+  typingIndicatorSetting: await window.getTypingIndicatorSetting(),
+  linkPreviewSetting: await window.getLinkPreviewSetting(),
+
   isPrimary: await window.isPrimary(),
   lastSyncTime: await window.getLastSyncTime(),
 });

--- a/js/views/settings_view.js
+++ b/js/views/settings_view.js
@@ -191,6 +191,26 @@
         value: window.initialData.mediaCameraPermissions,
         setFn: window.setMediaCameraPermissions,
       });
+      new CheckboxView({
+        el: this.$('.read-receipt-setting'),
+        value: window.initialData.readReceiptSetting,
+        setFn: window.setReadReceiptSetting,
+      });
+      new CheckboxView({
+        el: this.$('.unidentified-delivery-indicator-setting'),
+        value: window.initialData.unidentifiedDeliveryIndicatorSetting,
+        setFn: window.setUnidentifiedDeliveryIndicatorSetting,
+      });
+      new CheckboxView({
+        el: this.$('.typing-indicator-setting'),
+        value: window.initialData.typingIndicatorSetting,
+        setFn: window.setTypingIndicatorSetting,
+      });
+      new CheckboxView({
+        el: this.$('.link-preview-setting'),
+        value: window.initialData.linkPreviewSetting,
+        setFn: window.setLinkPreviewSetting,
+      });
       if (!window.initialData.isPrimary) {
         const syncView = new SyncView().render();
         this.$('.sync-setting').append(syncView.el);
@@ -249,6 +269,11 @@
         mediaCameraPermissionsDescription: i18n(
           'mediaCameraPermissionsDescription'
         ),
+        privacySettings: i18n('privacySettings'),
+        sendReadReceipts: i18n('sendReadReceipts'),
+        udIndicators: i18n('udIndicators'),
+        typingIndicators: i18n('typingIndicators'),
+        linkPreviews: i18n('linkPreviews'),
         generalHeader: i18n('general'),
         spellCheckDescription: i18n('spellCheckDescription'),
         spellCheckHidden: spellCheckDirty ? 'false' : 'true',

--- a/main.js
+++ b/main.js
@@ -1277,6 +1277,15 @@ installSettingsSetter('badge-count-muted-conversations');
 installSettingsGetter('spell-check');
 installSettingsSetter('spell-check');
 
+installSettingsGetter('read-receipt-setting');
+installSettingsSetter('read-receipt-setting');
+installSettingsGetter('unidentified-delivery-indicator-setting');
+installSettingsSetter('unidentified-delivery-indicator-setting');
+installSettingsGetter('typing-indicator-setting');
+installSettingsSetter('typing-indicator-setting');
+installSettingsGetter('link-preview-setting');
+installSettingsSetter('link-preview-setting');
+
 installSettingsGetter('always-relay-calls');
 installSettingsSetter('always-relay-calls');
 installSettingsGetter('call-ringtone-notification');

--- a/preload.js
+++ b/preload.js
@@ -189,6 +189,21 @@ try {
   installGetter('spell-check', 'getSpellCheck');
   installSetter('spell-check', 'setSpellCheck');
 
+  installGetter('read-receipt-setting', 'getReadReceiptSetting');
+  installSetter('read-receipt-setting', 'setReadReceiptSetting');
+  installGetter(
+    'unidentified-delivery-indicator-setting',
+    'getUnidentifiedDeliveryIndicatorSetting'
+  );
+  installSetter(
+    'unidentified-delivery-indicator-setting',
+    'setUnidentifiedDeliveryIndicatorSetting'
+  );
+  installGetter('typing-indicator-setting', 'getTypingIndicatorSetting');
+  installSetter('typing-indicator-setting', 'setTypingIndicatorSetting');
+  installGetter('link-preview-setting', 'getLinkPreviewSetting');
+  installSetter('link-preview-setting', 'setLinkPreviewSetting');
+
   installGetter('always-relay-calls', 'getAlwaysRelayCalls');
   installSetter('always-relay-calls', 'setAlwaysRelayCalls');
 

--- a/settings.html
+++ b/settings.html
@@ -152,6 +152,25 @@
         <label for='media-camera-permissions'>{{ mediaCameraPermissionsDescription }}</label>
       </div>
     </div>
+    <div class='privacy-setting'>
+      <h3>{{ privacySettings }}</h3>
+      <div class='read-receipt-setting'>
+        <input type='checkbox' name='read-receipt-setting' id='read-receipt-setting'/>
+        <label for='read-receipt-setting'>{{ sendReadReceipts }}</label>
+      </div>
+      <div class='unidentified-delivery-indicator-setting'>
+        <input type='checkbox' name='unidentified-delivery-indicator-setting' id='unidentified-delivery-indicator-setting'/>
+        <label for='unidentified-delivery-indicator-setting'>{{ udIndicators }}</label>
+      </div>
+      <div class='typing-indicator-setting'>
+        <input type='checkbox' name='typing-indicator-setting' id='typing-indicator-setting'/>
+        <label for='typing-indicator-setting'>{{ typingIndicators }}</label>
+      </div>
+      <div class='link-preview-setting'>
+        <input type='checkbox' name='link-preview-setting' id='link-preview-setting'/>
+        <label for='link-preview-setting'>{{ linkPreviews }}</label>
+      </div>
+    </div>
     <div class='sync-setting'></div>
     <hr>
     <div class='clear-data-settings'>

--- a/settings_preload.js
+++ b/settings_preload.js
@@ -82,6 +82,19 @@ window.setMediaPermissions = makeSetter('media-permissions');
 window.getMediaCameraPermissions = makeGetter('media-camera-permissions');
 window.setMediaCameraPermissions = makeSetter('media-camera-permissions');
 
+window.getReadReceiptSetting = makeGetter('read-receipt-setting');
+window.setReadReceiptSetting = makeSetter('read-receipt-setting');
+window.getUnidentifiedDeliveryIndicatorSetting = makeGetter(
+  'unidentified-delivery-indicator-setting'
+);
+window.setUnidentifiedDeliveryIndicatorSetting = makeSetter(
+  'unidentified-delivery-indicator-setting'
+);
+window.getTypingIndicatorSetting = makeGetter('typing-indicator-setting');
+window.setTypingIndicatorSetting = makeSetter('typing-indicator-setting');
+window.getLinkPreviewSetting = makeGetter('link-preview-setting');
+window.setLinkPreviewSetting = makeSetter('link-preview-setting');
+
 window.isPrimary = makeGetter('is-primary');
 window.makeSyncRequest = makeGetter('sync-request');
 window.getLastSyncTime = makeGetter('sync-time');

--- a/ts/background.ts
+++ b/ts/background.ts
@@ -406,6 +406,20 @@ type WhatIsThis = typeof window.WhatIsThis;
         window.storage.put('spell-check', value);
       },
 
+      getReadReceiptSetting: () => window.storage.get('read-receipt-setting'),
+      setReadReceiptSetting: (value: boolean) =>
+        window.storage.put('read-receipt-setting', value),
+      getUnidentifiedDeliveryIndicatorSetting: () =>
+        window.storage.get('unidentifiedDeliveryIndicators'),
+      setUnidentifiedDeliveryIndicatorSetting: (value: boolean) =>
+        window.storage.put('unidentifiedDeliveryIndicators', value),
+      getTypingIndicatorSetting: () => window.storage.get('typingIndicators'),
+      setTypingIndicatorSetting: (value: boolean) =>
+        window.storage.put('typingIndicators', value),
+      getLinkPreviewSetting: () => window.storage.get('linkPreviews'),
+      setLinkPreviewSetting: (value: boolean) =>
+        window.storage.put('linkPreviews', value),
+
       getAlwaysRelayCalls: () => window.storage.get('always-relay-calls'),
       setAlwaysRelayCalls: (value: WhatIsThis) =>
         window.storage.put('always-relay-calls', value),


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

The possibility to change four settings was added:
- read-receipt-setting
- unidentified-delivery-indicator-setting
- typing-indicator-setting
- link-preview-setting

Those settings were already present before, but it was only possible to change them in the smartphone app.

Resolves #6 
