### PR TITLE
Enhancement/#4 synchronization

### DIFF
--- a/ts/textsecure.d.ts
+++ b/ts/textsecure.d.ts
@@ -8,7 +8,7 @@ import Crypto from './textsecure/Crypto';
 import MessageReceiver from './textsecure/MessageReceiver';
 import MessageSender from './textsecure/SendMessage';
 import EventTarget from './textsecure/EventTarget';
-import { ByteBufferClass } from './window.d';
+import { ByteBufferClass, WhatIsThis } from './window.d';
 import SendMessage, { SendOptionsType } from './textsecure/SendMessage';
 import { WebAPIType } from './textsecure/WebAPI';
 import utils from './textsecure/Helpers';
@@ -82,12 +82,17 @@ export type TextSecureType = {
   messaging: SendMessage;
   protobuf: ProtobufCollectionType;
   utils: typeof utils;
+  StringView: StringViewType;
 
   EventTarget: typeof EventTarget;
   MessageReceiver: typeof MessageReceiver;
   AccountManager: WhatIsThis;
   MessageSender: WhatIsThis;
   SyncRequest: WhatIsThis;
+};
+
+type StringViewType = {
+  base64ToBytes: (sBase64: string, nBlocksSize?: number) => ArrayBuffer;
 };
 
 type StoredSignedPreKeyType = SignedPreKeyType & {

--- a/ts/textsecure.d.ts
+++ b/ts/textsecure.d.ts
@@ -502,6 +502,7 @@ export declare class ContactDetailsClass {
     data: ArrayBuffer | ByteBufferClass,
     encoding?: string
   ) => ContactDetailsClass;
+  toArrayBuffer: () => ArrayBuffer;
 
   number?: string;
   uuid?: string;
@@ -739,6 +740,7 @@ export declare class GroupDetailsClass {
     data: ArrayBuffer | ByteBufferClass,
     encoding?: string
   ) => GroupDetailsClass;
+  toArrayBuffer: () => ArrayBuffer;
 
   id?: ProtoBinaryType;
   name?: string;

--- a/ts/textsecure/AccountManager.ts
+++ b/ts/textsecure/AccountManager.ts
@@ -155,6 +155,7 @@ export default class AccountManager extends EventTarget {
         provisionMessage.number = window.textsecure.storage.user.getNumber();
         provisionMessage.provisioningCode = code;
         provisionMessage.profileKey = profileKey;
+        provisionMessage.uuid = window.textsecure.storage.user.getUuid();
 
         const provisioningCipher = new ProvisioningCipher();
         return provisioningCipher
@@ -188,6 +189,7 @@ export default class AccountManager extends EventTarget {
             verificationCode,
             identityKeyPair,
             profileKey,
+            null,
             null,
             null,
             null,
@@ -295,6 +297,7 @@ export default class AccountManager extends EventTarget {
                               provisionMessage.identityKeyPair,
                               provisionMessage.profileKey,
                               deviceName,
+                              provisionMessage.uuid || null,
                               provisionMessage.userAgent,
                               provisionMessage.readReceipts,
                               { uuid: provisionMessage.uuid }
@@ -515,6 +518,7 @@ export default class AccountManager extends EventTarget {
     identityKeyPair: KeyPairType,
     profileKey: ArrayBuffer | undefined,
     deviceName: string | null,
+    uuid: string | null,
     userAgent?: string | null,
     readReceipts?: boolean | null,
     options: { accessKey?: ArrayBuffer; uuid?: string } = {}
@@ -608,7 +612,7 @@ export default class AccountManager extends EventTarget {
       deviceName
     );
 
-    const setUuid = response.uuid;
+    const setUuid = response.uuid || uuid;
     if (setUuid) {
       await window.textsecure.storage.user.setUuidAndDeviceId(
         setUuid,
@@ -619,7 +623,7 @@ export default class AccountManager extends EventTarget {
     // update our own identity key, which may have changed
     // if we're relinking after a reinstall on the master device
     await window.textsecure.storage.protocol.saveIdentityWithAttributes(
-      number,
+      setUuid,
       {
         publicKey: identityKeyPair.pubKey,
         firstUse: true,

--- a/ts/textsecure/MessageReceiver.ts
+++ b/ts/textsecure/MessageReceiver.ts
@@ -1543,8 +1543,7 @@ class MessageReceiverInner extends EventTarget {
     }
     if (syncMessage.request) {
       window.log.info('Got SyncMessage Request');
-      this.removeFromCache(envelope);
-      return undefined;
+      return this.handleSyncRequest(envelope, syncMessage.request);
     }
     if (syncMessage.read && syncMessage.read.length) {
       window.log.info('read messages from', this.getEnvelopeId(envelope));
@@ -1583,6 +1582,34 @@ class MessageReceiverInner extends EventTarget {
 
     this.removeFromCache(envelope);
     throw new Error('Got empty SyncMessage');
+  }
+
+  async handleSyncRequest(
+    envelope: EnvelopeClass,
+    request: SyncMessageClass.Request
+  ) {
+    let ev = null;
+
+    switch (request.type) {
+      case 1:
+        window.log.info('got contact sync request');
+        ev = new Event('contactSyncRequest');
+        break;
+      case 2:
+        window.log.info('got group sync request');
+        ev = new Event('groupSyncRequest');
+        break;
+      case 4:
+        window.log.info('got configuration sync request');
+        ev = new Event('configurationSyncRequest');
+        break;
+      default:
+        throw new Error(`${request.type} is a unknown sync request type.`);
+    }
+
+    this.removeFromCache(envelope);
+
+    return this.dispatchAndWait(ev);
   }
 
   async handleConfiguration(

--- a/ts/textsecure/ProvisioningCipher.ts
+++ b/ts/textsecure/ProvisioningCipher.ts
@@ -66,6 +66,7 @@ class ProvisioningCipherInner {
               provisioningCode: provisionMessage.provisioningCode,
               userAgent: provisionMessage.userAgent,
               readReceipts: provisionMessage.readReceipts,
+              uuid: provisionMessage.uuid,
             };
             if (provisionMessage.profileKey) {
               ret.profileKey = provisionMessage.profileKey.toArrayBuffer();

--- a/ts/textsecure/WebAPI.ts
+++ b/ts/textsecure/WebAPI.ts
@@ -1486,7 +1486,8 @@ export function initialize({
       return _ajax({
         call: 'keys',
         httpType: 'GET',
-        urlParameters: `/${identifier}/${deviceId || '*'}`,
+        urlParameters: `/${identifier}/${(deviceId === 1 ? '*' : deviceId) ||
+          '*'}`,
         responseType: 'json',
         validateResponse: { identityKey: 'string', devices: 'object' },
       }).then(handleKeys);

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -38,12 +38,13 @@ import { combineNames } from './util';
 import { BatcherType } from './util/batcher';
 import { ErrorModal } from './components/ErrorModal';
 import { ProgressModal } from './components/ProgressModal';
+import StringView from './textsecure/StringView';
 
 export { Long } from 'long';
 
 type TaskResultType = any;
 
-type WhatIsThis = any;
+export type WhatIsThis = any;
 
 declare global {
   interface Window {

--- a/ts/window.d.ts
+++ b/ts/window.d.ts
@@ -502,6 +502,7 @@ export class ByteBufferClass {
   readLong: (offset: number) => Long;
   readShort: (offset: number) => number;
   readVarint32: () => number;
+  writeVarint32: (value: number) => ByteBufferClass;
   writeLong: (l: Long) => void;
   skip: (length: number) => void;
 }


### PR DESCRIPTION
### Contributor checklist:

- [x] My commits are in nice logical chunks with [good commit messages](http://chris.beams.io/posts/git-commit/)
- [x] My changes are [rebased](https://medium.freecodecamp.org/git-rebase-and-the-golden-rule-explained-70715eccc372) on the latest [`development`](https://github.com/signalapp/Signal-Desktop/tree/development) branch
- [x] A `yarn ready` run passes successfully ([more about tests here](https://github.com/signalapp/Signal-Desktop/blob/master/CONTRIBUTING.md#tests))
- [x] My changes are ready to be shipped to users

### Description

It is now possible to synchronize contacts, groups and the configuration between multiple linked devices.
The synchronization is just one-way, from the primary device to the secondary ones. Therefore changes made in the secondary device might get overwritten on the next synchronization.

There was also a bug in handling the identity keys after the linking, but it is now resolved by storing the identity keys for oneself by the UUID.

Resolves #4 